### PR TITLE
Proper ExitCode result

### DIFF
--- a/Streamlink for Windows (Compiled)/Files/Resources/PORTABLE_BUILD.vb
+++ b/Streamlink for Windows (Compiled)/Files/Resources/PORTABLE_BUILD.vb
@@ -54,6 +54,7 @@ Module Module1
         proc.WaitForExit()
         'Threading.Thread.Sleep(Threading.Timeout.Infinite)
         Console.WriteLine("[End of Streamlink for Windows]")
+        Environment.Exit(Proc.ExitCode)
     End Sub
 
     Public Function ControlHandler(ByVal ctrlType As CtrlTypes) As Boolean

--- a/Streamlink for Windows (Compiled)/Files/Resources/STANDALONE_BUILD.vb
+++ b/Streamlink for Windows (Compiled)/Files/Resources/STANDALONE_BUILD.vb
@@ -114,6 +114,7 @@ Module Module1
             Dim proc = Process.Start(info)
             proc.WaitForExit()
             Console.WriteLine("[End of Streamlink for Windows]")
+            Environment.Exit(Proc.ExitCode)
         Catch ex As Exception
             Console.WriteLine("[Streamlink] An error occurred")
         End Try


### PR DESCRIPTION
With this fix the executable can give the real Python exit code (needed in for example --can-handle-url  parameter)